### PR TITLE
Add Semi-Continuous mode for larger and slower files

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -145,11 +145,13 @@
             "type": "number",
             "enum": [
               0,
-              1
+              1,
+              2
             ],
             "enumItemLabels": [
               "Manual",
-              "Continuous"
+              "Continuous",
+              "SemiContinuous"
             ],
             "default": 1,
             "description": "Configures the proof checking mode for Coq."

--- a/client/src/Decorations.ts
+++ b/client/src/Decorations.ts
@@ -9,6 +9,7 @@ interface Decorations {
 }
 
 export let decorationsContinuous : Decorations;
+export let decorationsSemiContinuous : Decorations;
 export let decorationsManual : Decorations;
 
 export function initializeDecorations(context: vscode.ExtensionContext) {
@@ -31,6 +32,23 @@ export function initializeDecorations(context: vscode.ExtensionContext) {
         processed: create({
             overviewRulerColor: '#20b2aa', 
             overviewRulerLane: vscode.OverviewRulerLane.Left,
+        }),
+    };
+
+    decorationsSemiContinuous = {
+        parsed: create({
+            overviewRulerColor: 'cyan', 
+            overviewRulerLane: vscode.OverviewRulerLane.Right,
+        }),
+        processing: create({
+            overviewRulerColor: 'blue', 
+            overviewRulerLane: vscode.OverviewRulerLane.Center,
+        }),
+        processed: create({
+            overviewRulerColor: '#20b2aa', 
+            overviewRulerLane: vscode.OverviewRulerLane.Left,
+            light: {backgroundColor: 'rgba(0,150,0,0.2)'},
+            dark: {backgroundColor: 'rgba(0,150,0,0.2)'},
         }),
     };
 

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -7,7 +7,7 @@ import {
   integer
 } from 'vscode-languageclient/node';
 
-import {decorationsManual, decorationsContinuous} from './Decorations';
+import {decorationsManual, decorationsContinuous, decorationsSemiContinuous} from './Decorations';
 
 export default class Client extends LanguageClient {
 
@@ -62,6 +62,7 @@ export default class Client extends LanguageClient {
         editors.map(editor => {
             editor.setDecorations(decorationsManual.processed, []);
             editor.setDecorations(decorationsContinuous.processed, []);
+            editor.setDecorations(decorationsSemiContinuous.processed, []);
         });
     }
 
@@ -71,8 +72,10 @@ export default class Client extends LanguageClient {
         editors.map(editor => {
             if(config.mode === 0) {
                 editor.setDecorations(decorationsManual.processed, ranges);
-            } else {
+            } else if (config.mode === 1) {
                 editor.setDecorations(decorationsContinuous.processed, ranges);
+            } else {
+                editor.setDecorations(decorationsSemiContinuous.processed, ranges);
             }
         });
     }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -268,7 +268,7 @@ Path: \`${coqTM.getVsCoqTopPath()}\`
             let goalsHook = window.onDidChangeTextEditorSelection(
                 (evt: TextEditorSelectionChangeEvent) => {                    
                     if (evt.textEditor.document.languageId === "coq"
-                        && workspace.getConfiguration('vscoq.proof').mode === 1)
+                        && (workspace.getConfiguration('vscoq.proof').mode === 1 || workspace.getConfiguration('vscoq.proof').mode === 2))
                     {
                         sendInterpretToPoint(evt.textEditor, client);
                     }

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -40,20 +40,20 @@ val apply_text_edits : state -> text_edit list -> state
     document is parsed, outdated executions states are invalidated, and the observe
     id is updated. *)
 
-val interpret_to_position : stateful:bool -> state -> Position.t -> (state * events)
+val interpret_to_position : skip_proofs:bool -> stateful:bool -> state -> Position.t -> (state * events)
 (** [interpret_to_position stateful doc pos] navigates to the last sentence ending
     before or at [pos] and returns the resulting state. The [stateful] flag 
     determines if we record the resulting position in the state. *)
 
-val interpret_to_previous : state -> (state * events)
+val interpret_to_previous : skip_proofs:bool -> state -> (state * events)
 (** [interpret_to_previous doc] navigates to the previous sentence in [doc]
     and returns the resulting state. *)
 
-val interpret_to_next : state -> (state * events)
+val interpret_to_next : skip_proofs:bool -> state -> (state * events)
 (** [interpret_to_next doc] navigates to the next sentence in [doc]
     and returns the resulting state. *)
 
-val interpret_to_end : state -> (state * events)
+val interpret_to_end : skip_proofs:bool -> state -> (state * events)
 (** [interpret_to_end doc] navigates to the last sentence in [doc]
     and returns the resulting state. *)
 

--- a/language-server/dm/executionManager.mli
+++ b/language-server/dm/executionManager.mli
@@ -71,7 +71,7 @@ val handle_event : event -> state -> (state option * events)
 (** Execution happens in two steps. In particular the event one takes only
     one task at a time to ease checking for interruption *)
 type prepared_task
-val build_tasks_for : Scheduler.schedule -> state -> sentence_id -> Vernacstate.t * prepared_task list
+val build_tasks_for : skip_proofs:bool -> Scheduler.schedule -> state -> sentence_id -> Vernacstate.t * prepared_task list
 val execute : state -> Vernacstate.t * events * bool -> prepared_task -> (state * Vernacstate.t * events * bool)
 
 (** Coq toplevels for delegation without fork *)

--- a/language-server/dm/scheduler.mli
+++ b/language-server/dm/scheduler.mli
@@ -43,6 +43,10 @@ type task =
                      proof_using: Vernacexpr.section_subset_expr;
                      tasks : executable_sentence list; (* non empty list *)
                    }
+  | NonOpaqueProof of { terminator: executable_sentence;
+                        opener_id: sentence_id;
+                        tasks : executable_sentence list; (* non empty list *)
+                      }
   | Query of executable_sentence
 
 type schedule

--- a/language-server/protocol/settings.ml
+++ b/language-server/protocol/settings.ml
@@ -37,15 +37,18 @@ module Mode = struct
   type t =
   | Continuous 
   | Manual
+  | SemiContinuous
   [@@deriving yojson]
     
   let yojson_of_t = function
   | Manual -> `Int 0
   | Continuous -> `Int 1
+  | SemiContinuous -> `Int 2
 
   let t_of_yojson = function
   | `Int 0 -> Manual
   | `Int 1 -> Continuous
+  | `Int 2 -> SemiContinuous
   | _ -> Yojson.json_error @@ "invalid value "
 
 end


### PR DESCRIPTION
This PR adds a 'SemiContinuous' mode as a compromise between continually checking in the background, but skipping proofs in the foreground.

Using this mode, the proof state at the cursor can be determined more quickly, as prior proofs are skipped. However, the continuous checker is still run in the background to continually check all proofs in the file.

Additionally, a new `NonOpaqueProof` task is added for proofs which are not opaque and cannot be delegated, but can still be skipped using the `Skip` option or in `SemiContinuous` mode.


Even using `SemiContinuous` mode, changing the cursor position may be slow as LSP commands are currently run at 1 byte per loop (hence 1 byte per background Coq command). The following SEL pull request allows LSP commands to be read in one iteration:
https://github.com/gares/sel/pull/10