### PR TITLE
syntax: Highlight Goal in any context

### DIFF
--- a/client/syntax/coq.tmLanguage.json
+++ b/client/syntax/coq.tmLanguage.json
@@ -15,7 +15,7 @@
       "name": "keyword.control.import.coq"
     },
     {
-      "match": "\\b(Theorem|Lemma|Remark|Fact|Corollary|Property|Proposition|Goal)\\s+((\\p{L}|[_\\u00A0])(\\p{L}|[0-9_\\u00A0'])*)",
+      "match": "\\b(Theorem|Lemma|Remark|Fact|Corollary|Property|Proposition)\\s+((\\p{L}|[_\\u00A0])(\\p{L}|[0-9_\\u00A0'])*)",
       "comment": "Theorem declarations",
       "captures": {
         "1": {
@@ -25,6 +25,10 @@
           "name": "entity.name.function.theorem.coq"
         }
       }
+    },
+    {
+      "match": "\\bGoal\\b",
+      "name": "keyword.source.coq"
     },
     {
       "match": "\\b(Parameters?|Axioms?|Conjectures?|Variables?|Hypothesis|Hypotheses)(\\s+Inline)?\\b\\s*\\(?\\s*((\\p{L}|[_\\u00A0])(\\p{L}|[0-9_\\u00A0'])*)",


### PR DESCRIPTION
Reported by Thomas Lamiaux on Zulip. `Goal` is followed directly by the proposition to prove, which can be any term so, unlike `Theorem` etc., it's practically impossible to use lookarounds to disambiguate the `Goal` command from an identifier.

```
Goal prop.
(* different from *)
Theorem ident : prop.
```

