### PR TITLE
Interupt consecutive parsing events

### DIFF
--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -38,14 +38,17 @@ val pp_event : Format.formatter -> event -> unit
 
 type events = event Sel.Event.t list
 
-val init : Vernacstate.t -> opts:Coqargs.injection_command list -> DocumentUri.t -> text:string -> observe_id option -> state * events
+val init : Vernacstate.t -> opts:Coqargs.injection_command list -> DocumentUri.t -> text:string -> background:bool -> block_on_error:bool -> observe_id option -> state * events
 (** [init st opts uri text] initializes the document manager with initial vernac state
-    [st] on which command line opts will be set. *)
+    [st] on which command line opts will be set. [background] indicates if the document should
+    be executed in the background once it is parsed. *)
 
-val apply_text_edits : state -> text_edit list -> state
-(** [apply_text_edits doc edits] updates the text of [doc] with [edits]. The new
+val apply_text_edits : state -> text_edit list -> background:bool -> block_on_error:bool -> events
+(** [apply_text_edits doc edits] updates the text of [doc] with [edits]. 
+    A ParseEvent is triggered, once processed: the new
     document is parsed, outdated executions states are invalidated, and the observe
-    id is updated. *)
+    id is updated. Finally if [background] is set to true, an execution is launched in
+    the background *)
 
 val clear_observe_id : state -> state
 (** [clear_observe_id state] updates the state to make the observe_id None *)
@@ -83,7 +86,7 @@ val interpret_in_background : state -> should_block_on_error:bool -> (state * ev
 (** [interpret_in_background doc] same as [interpret_to_end] but computation 
     is done in background (with lower priority) *)
 
-val reset : state -> state * events
+val reset : state -> background:bool -> block_on_error:bool -> state * events
 (** resets Coq *)
 
 val executed_ranges : state -> exec_overview

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -34,6 +34,7 @@ type blocking_error = {
 type state
 
 type event
+type event_with_uri = DocumentUri.t * event
 val pp_event : Format.formatter -> event -> unit
 
 type events = event Sel.Event.t list
@@ -112,6 +113,8 @@ val get_proof : state -> Settings.Goals.Diff.Mode.t -> Position.t option -> Proo
 
 val get_completions : state -> Position.t -> (completion_item list, string) Result.t
 
+val filter_events : event_with_uri list -> event_with_uri list
+(** filter document manager events so the contain only the latest parsing event *)
 val handle_event : event -> state -> bool -> (state option * events * blocking_error option)
 (** handles events and returns a new state if it was updated *)
 

--- a/language-server/dm/priorityManager.ml
+++ b/language-server/dm/priorityManager.ml
@@ -1,8 +1,8 @@
 (* This filecontains the global views of priorities *)
 
-let lsp_message = -3
-let feedback = -5
+let lsp_message = -5
+let feedback = -6
 let parsing = -4
 let execution = -3
 let proof_view = -2
-let move_cursor = -6
+let move_cursor = -7

--- a/language-server/dm/priorityManager.ml
+++ b/language-server/dm/priorityManager.ml
@@ -1,7 +1,8 @@
 (* This filecontains the global views of priorities *)
 
 let lsp_message = -3
-let feedback = -4
+let feedback = -5
+let parsing = -4
 let execution = -3
 let proof_view = -2
-let move_cursor = -5
+let move_cursor = -6

--- a/language-server/vscoqtop/lspManager.mli
+++ b/language-server/vscoqtop/lspManager.mli
@@ -15,6 +15,7 @@
 type event
 type events = event Sel.Event.t list
 
+val filter_events : event list -> event list
 val handle_event : event -> events
 val pr_event : event -> Pp.t
 


### PR DESCRIPTION
Currently, as outlined in #682, each time a document is edited, a full parsing is triggered. This cam be problematic and could be at the origin of #914.
The aim of this PR is to make parsing part of the event loop which can then be optimised to only keep the last event.