### PR TITLE
0 based cloumn number

### DIFF
--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -55,7 +55,7 @@ let position_of_loc raw loc =
   while (!i < Array.length raw.lines && raw.lines.(!i) <= loc) do incr(i) done;
   let line = !i - 1 in
   let char = get_character_pos (line_text raw line) (loc - raw.lines.(line)) in
-  Position.{ line = line; character = char }
+  Position.{ line = line; character = max 0 (char-1) }
 
 let get_character_loc linestr pos =
   let rec loop d =


### PR DESCRIPTION
This seems to fix #950 but I really don't get if it is hiding a bug in uutf or in out logic... 

*but* it breaks the overview (see the last `.` is not green). So I have to understand what is wrong/right

![Screenshot from 2024-12-04 13-37-00](https://github.com/user-attachments/assets/871afea2-883e-4673-aed7-fa12c3f16575)

Fix #950 