### PR TITLE
Get proof blocks api

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -4,7 +4,6 @@ import {
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
-  integer
 } from 'vscode-languageclient/node';
 
 import {decorationsManual, decorationsContinuous, decorationsErrorAnimation} from './Decorations';

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -27,6 +27,8 @@ import GoalPanel from './panels/GoalPanel';
 import SearchViewProvider from './panels/SearchViewProvider';
 import {
     CoqLogMessage,
+    DocumentProofsRequest,
+    DocumentProofsResponse,
     ErrorAlertNotification,
     MoveCursorNotification, 
     ProofViewNotification, 
@@ -184,6 +186,22 @@ export function activate(context: ExtensionContext) {
                     searchProvider.launchQuery(queryText, type);
                 }
             });
+        };
+
+        const getDocumentProofs = (editor: TextEditor) => {
+            const uri = editor.document.uri;
+            const textDocument = TextDocumentIdentifier.create(uri.toString());
+            const params: DocumentProofsRequest = {textDocument};
+            const req = new RequestType<DocumentProofsRequest, DocumentProofsResponse, void>("vscoq/documentProofs");
+            Client.writeToVscoq2Channel("Getting proofs for: " + uri.toString());
+            client.sendRequest(req, params).then(
+                (res) => {
+                    return res;
+                }, 
+                (err) => {
+                    window.showErrorMessage(err);
+                }
+            );
         };
 
         registerVscoqTextCommand('reset', (editor) => {
@@ -368,7 +386,13 @@ Path: \`${coqTM.getVsCoqTopPath()}\`
         });
 
         context.subscriptions.push(client);
-    }	
+
+        const externalApi = {
+            getDocumentProofs
+        };
+
+        return externalApi;
+    }
 
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -62,6 +62,21 @@ export function activate(context: ExtensionContext) {
         });
     }
 
+    const getDocumentProofs = (uri: VersionedTextDocumentIdentifier) => {
+        const textDocument = TextDocumentIdentifier.create(uri.toString());
+        const params: DocumentProofsRequest = {textDocument};
+        const req = new RequestType<DocumentProofsRequest, DocumentProofsResponse, void>("vscoq/documentProofs");
+        Client.writeToVscoq2Channel("Getting proofs for: " + uri.toString());
+        client.sendRequest(req, params).then(
+            (res) => {
+                return res;
+            }, 
+            (err) => {
+                window.showErrorMessage(err);
+            }
+        );
+    };
+
     // Watch for files being added or removed
     workspace.onDidCreateFiles(checkInCoqProject);
     workspace.onDidDeleteFiles(checkInCoqProject);
@@ -187,21 +202,6 @@ export function activate(context: ExtensionContext) {
                     searchProvider.launchQuery(queryText, type);
                 }
             });
-        };
-
-        const getDocumentProofs = (uri: VersionedTextDocumentIdentifier) => {
-            const textDocument = TextDocumentIdentifier.create(uri.toString());
-            const params: DocumentProofsRequest = {textDocument};
-            const req = new RequestType<DocumentProofsRequest, DocumentProofsResponse, void>("vscoq/documentProofs");
-            Client.writeToVscoq2Channel("Getting proofs for: " + uri.toString());
-            client.sendRequest(req, params).then(
-                (res) => {
-                    return res;
-                }, 
-                (err) => {
-                    window.showErrorMessage(err);
-                }
-            );
         };
 
         registerVscoqTextCommand('reset', (editor) => {
@@ -386,13 +386,13 @@ Path: \`${coqTM.getVsCoqTopPath()}\`
         });
 
         context.subscriptions.push(client);
-
-        const externalApi = {
-            getDocumentProofs
-        };
-
-        return externalApi;
     }
+
+    const externalApi = {
+        getDocumentProofs
+    };
+
+    return externalApi;
 
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,6 +17,7 @@ import {
   RequestType,
   ServerOptions,
   TextDocumentIdentifier,
+  VersionedTextDocumentIdentifier,
 } from 'vscode-languageclient/node';
 
 import Client from './client';
@@ -188,8 +189,7 @@ export function activate(context: ExtensionContext) {
             });
         };
 
-        const getDocumentProofs = (editor: TextEditor) => {
-            const uri = editor.document.uri;
+        const getDocumentProofs = (uri: VersionedTextDocumentIdentifier) => {
             const textDocument = TextDocumentIdentifier.create(uri.toString());
             const params: DocumentProofsRequest = {textDocument};
             const req = new RequestType<DocumentProofsRequest, DocumentProofsResponse, void>("vscoq/documentProofs");

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,7 +17,6 @@ import {
   RequestType,
   ServerOptions,
   TextDocumentIdentifier,
-  VersionedTextDocumentIdentifier,
 } from 'vscode-languageclient/node';
 
 import Client from './client';
@@ -62,19 +61,12 @@ export function activate(context: ExtensionContext) {
         });
     }
 
-    const getDocumentProofs = (uri: VersionedTextDocumentIdentifier) => {
+    const getDocumentProofs = (uri: Uri) => {
         const textDocument = TextDocumentIdentifier.create(uri.toString());
         const params: DocumentProofsRequest = {textDocument};
         const req = new RequestType<DocumentProofsRequest, DocumentProofsResponse, void>("vscoq/documentProofs");
         Client.writeToVscoq2Channel("Getting proofs for: " + uri.toString());
-        client.sendRequest(req, params).then(
-            (res) => {
-                return res;
-            }, 
-            (err) => {
-                window.showErrorMessage(err);
-            }
-        );
+        return client.sendRequest(req, params);
     };
 
     // Watch for files being added or removed

--- a/client/src/protocol/types.ts
+++ b/client/src/protocol/types.ts
@@ -144,3 +144,22 @@ export interface ResetCoqRequest {
 }
 
 export interface ResetCoqResponse {};
+
+export interface DocumentProofsRequest {
+    textDocument: TextDocumentIdentifier;
+}
+
+type proof_step = {
+    range: Range;
+    tactic: string;
+};
+
+type proof_block = {
+    statement: string;
+    range: Range;
+    proofs: proof_step[];
+};
+
+export interface DocumentProofsResponse {
+    proofs: proof_block[];
+}

--- a/client/src/protocol/types.ts
+++ b/client/src/protocol/types.ts
@@ -149,17 +149,22 @@ export interface DocumentProofsRequest {
     textDocument: TextDocumentIdentifier;
 }
 
-type proof_step = {
+type ProofStatement = {
+    range: Range;
+    statement: string;
+}
+
+type ProofStep = {
     range: Range;
     tactic: string;
 };
 
-type proof_block = {
-    statement: string;
+type ProofBlock = {
+    statement: ProofStatement;
     range: Range;
-    proofs: proof_step[];
+    steps: ProofStep[];
 };
 
 export interface DocumentProofsResponse {
-    proofs: proof_block[];
+    proofs: ProofBlock[];
 }

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -176,7 +176,7 @@ let push_proof_step_in_outline document id (outline : outline) =
 let record_outline document id (ast : Synterp.vernac_control_entry) classif (outline : outline) =
   let open Vernacextend in
   match classif with
-  | VtProofStep _ -> push_proof_step_in_outline document id outline
+  | VtProofStep _ | VtQed _ -> push_proof_step_in_outline document id outline
   | VtStartProof (_, names) ->
     let vernac_gen_expr = ast.v.expr in
     let type_ = match vernac_gen_expr with

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -179,13 +179,13 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
   | VtProofStep _ -> push_proof_step_in_outline document id outline
   | VtStartProof (_, names) ->
     let vernac_gen_expr = ast.v.expr in
-    let type_, statement = match vernac_gen_expr with
-      | VernacSynterp _ -> None, ""
+    let type_ = match vernac_gen_expr with
+      | VernacSynterp _ -> None
       | VernacSynPure pure -> 
         match pure with
-        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind), "theorem"
-        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def), "definition"
-        | _ -> None, ""
+        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind)
+        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def)
+        | _ -> None
     in
     let name = match names with
     |[] -> "default"
@@ -195,6 +195,7 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
     | None -> outline
     | Some type_ ->
       let range = range_of_id document id in
+      let statement = string_of_id document id in
       let element = {id; type_; name; statement; range; proof=[]} in
       element :: outline
     end
@@ -205,8 +206,8 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
       | VernacSynterp _ -> None, ""
       | VernacSynPure pure -> 
         match pure with
-        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind), "theroem"
-        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def), "definition"
+        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind), string_of_id document id
+        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def), string_of_id document id
         | _ -> None, ""
     in
     let name = match names with

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -27,12 +27,19 @@ type proof_block_type =
   | DefinitionType of Decls.definition_object_kind
   | Other
 
+type proof_step = {
+  id: sentence_id;
+  tactic: string;
+  range: Range.t;
+}
+
 type outline_element = {
     id: sentence_id;
     name: string;
     type_: proof_block_type;
     statement: string;
-    range: Range.t
+    proof: proof_step list;
+    range: Range.t;
   }
 
 type outline = outline_element list

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -328,10 +328,12 @@ let get_document_proofs st =
     | _ -> false
     in
   let mk_proof_block Document.{statement; proof; range } =
+    let statement = ProofState.mk_proof_statement statement range in
+    let last_step = List.hd proof in
+    let proof = List.rev proof in
+    let fst_step = List.hd proof in
+    let range = Range.create ~start:fst_step.range.start ~end_:last_step.range.end_ in
     let steps = List.map (fun Document.{tactic; range} -> ProofState.mk_proof_step tactic range) proof in
-    let step_ranges = List.map (fun (x: Document.proof_step) -> x.range) proof in
-    let range = List.fold_right RangeList.insert_or_merge_range step_ranges [range] in
-    let range = List.hd range in
     ProofState.mk_proof_block statement steps range
   in
   let proofs, _  = List.partition is_theorem outline in

--- a/language-server/dm/documentManager.mli
+++ b/language-server/dm/documentManager.mli
@@ -110,6 +110,8 @@ val get_info_messages : state -> Position.t option -> (DiagnosticSeverity.t * pp
 
 val get_document_symbols : state -> DocumentSymbol.t list
 
+val get_document_proofs : state -> ProofState.proof_block list
+
 val all_diagnostics : state -> Diagnostic.t list
 (** all_diagnostics [doc] returns the diagnostics corresponding to the sentences
     that have been executed in [doc]. *)

--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -102,6 +102,12 @@ let word_at_position raw pos : string option =
   with _ ->
     None
 
+let string_in_range raw start end_ =
+  try
+    String.sub raw.text start (end_ - start)
+  with _ -> (* TODO: ERROR *)
+    ""
+
 let apply_text_edit raw (Range.{start; end_}, editText) =
   let start = loc_of_position raw start in
   let stop = loc_of_position raw end_ in

--- a/language-server/dm/rawDocument.mli
+++ b/language-server/dm/rawDocument.mli
@@ -26,6 +26,7 @@ val end_loc : t -> int
 
 val range_of_loc : t -> Loc.t -> Range.t
 val word_at_position: t -> Position.t -> string option
+val string_in_range: t -> int -> int -> string
 
 (** Applies a text edit, and returns start location *)
 val apply_text_edit : t -> text_edit -> t * int

--- a/language-server/protocol/extProtocol.ml
+++ b/language-server/protocol/extProtocol.ml
@@ -251,7 +251,7 @@ module Request = struct
   module DocumentProofsParams = struct
     
     type t = {
-      textDocument: VersionedTextDocumentIdentifier.t
+      textDocument: TextDocumentIdentifier.t
     } [@@deriving yojson]
 
   end

--- a/language-server/protocol/extProtocol.ml
+++ b/language-server/protocol/extProtocol.ml
@@ -248,6 +248,22 @@ module Request = struct
 
   end
 
+  module DocumentProofsParams = struct
+    
+    type t = {
+      textDocument: VersionedTextDocumentIdentifier.t
+    } [@@deriving yojson]
+
+  end
+
+  module DocumentProofsResult = struct
+    
+    type t = {
+      proofs: ProofState.proof_block list;
+    } [@@deriving yojson]
+
+  end
+
   type 'a t =
   | Std : 'a Lsp.Client_request.t -> 'a t
   | Reset : ResetParams.t -> unit t
@@ -257,6 +273,7 @@ module Request = struct
   | Print : PrintParams.t -> pp t
   | Search : SearchParams.t -> unit t
   | DocumentState : DocumentStateParams.t -> DocumentStateResult.t t
+  | DocumentProofs : DocumentProofsParams.t -> DocumentProofsResult.t t
 
   type packed = Pack : 'a t -> packed
 
@@ -284,6 +301,9 @@ module Request = struct
     | "vscoq/documentState" ->
       let+ params = Lsp.Import.Json.message_params params DocumentStateParams.t_of_yojson in
       Pack (DocumentState params)
+    | "vscoq/documentProofs" ->
+      let+ params = Lsp.Import.Json.message_params params DocumentProofsParams.t_of_yojson in
+      Pack (DocumentProofs params)
     | _ ->
       let+ E req = Lsp.Client_request.of_jsonrpc req in
       Pack (Std req)
@@ -298,6 +318,7 @@ module Request = struct
       | Print _ -> yojson_of_pp resp
       | Search _ -> yojson_of_unit resp
       | DocumentState _ -> DocumentStateResult.(yojson_of_t resp)
+      | DocumentProofs _ -> DocumentProofsResult.(yojson_of_t resp)
       | Std req -> Lsp.Client_request.yojson_of_result req resp
 
   end

--- a/language-server/protocol/proofState.ml
+++ b/language-server/protocol/proofState.ml
@@ -17,13 +17,18 @@ open Lsp.Types
 
 open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
+type proof_statement = {
+  statement: string;
+  range: Range.t;
+} [@@deriving yojson]
+
 type proof_step = {
   tactic: string;
   range: Range.t;
 } [@@deriving yojson]
 
 type proof_block = {
-  statement: string;
+  statement: proof_statement;
   range: Range.t;
   steps: proof_step list;
 } [@@deriving yojson]
@@ -132,6 +137,8 @@ let get_proof ~previous diff_mode st =
       unfocusedGoals;
     }
 
+let mk_proof_statement statement range = {statement; range}
+
 let mk_proof_step tactic range = {tactic; range}
 
-let mk_proof_block statement steps range = {statement; steps; range}
+let mk_proof_block statement steps range = {steps; statement; range}

--- a/language-server/protocol/proofState.ml
+++ b/language-server/protocol/proofState.ml
@@ -13,8 +13,20 @@
 (**************************************************************************)
 
 open Printing
+open Lsp.Types
 
 open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+type proof_step = {
+  tactic: string;
+  range: Range.t;
+} [@@deriving yojson]
+
+type proof_block = {
+  statement: string;
+  range: Range.t;
+  steps: proof_step list;
+} [@@deriving yojson]
 
 type goal = {
   id: int;
@@ -119,3 +131,7 @@ let get_proof ~previous diff_mode st =
       givenUpGoals;
       unfocusedGoals;
     }
+
+let mk_proof_step tactic range = {tactic; range}
+
+let mk_proof_block statement steps range = {statement; steps; range}

--- a/language-server/protocol/proofState.mli
+++ b/language-server/protocol/proofState.mli
@@ -13,6 +13,8 @@
 (**************************************************************************)
 open Settings
 
+type proof_statement [@@deriving yojson]
+
 type proof_step [@@deriving yojson]
 
 type proof_block [@@deriving yojson]
@@ -21,5 +23,6 @@ type t [@@deriving yojson]
 
 val get_proof : previous:Vernacstate.t option -> Goals.Diff.Mode.t -> Vernacstate.t -> t option
 
+val mk_proof_statement : string -> Lsp.Types.Range.t -> proof_statement
 val mk_proof_step : string -> Lsp.Types.Range.t -> proof_step
-val mk_proof_block : string -> proof_step list -> Lsp.Types.Range.t -> proof_block
+val mk_proof_block : proof_statement -> proof_step list -> Lsp.Types.Range.t -> proof_block

--- a/language-server/protocol/proofState.mli
+++ b/language-server/protocol/proofState.mli
@@ -13,6 +13,13 @@
 (**************************************************************************)
 open Settings
 
+type proof_step [@@deriving yojson]
+
+type proof_block [@@deriving yojson]
+
 type t [@@deriving yojson]
 
 val get_proof : previous:Vernacstate.t option -> Goals.Diff.Mode.t -> Vernacstate.t -> t option
+
+val mk_proof_step : string -> Lsp.Types.Range.t -> proof_step
+val mk_proof_block : string -> proof_step list -> Lsp.Types.Range.t -> proof_block

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -551,8 +551,12 @@ let sendDocumentProofs id params =
   let uri = textDocument.uri in
   match Hashtbl.find_opt states (DocumentUri.to_path uri) with
   | None -> log @@ "[documentProofs] ignoring event on non existent document"; Error({message="Document does not exist"; code=None}), []
-  | Some { st } -> let proofs = Dm.DocumentManager.get_document_proofs st in
-    Ok Request.Client.DocumentProofsResult.{ proofs }, []
+  | Some { st } ->
+    if Dm.DocumentManager.is_parsing st then
+      Error {code=(Some Jsonrpc.Response.Error.Code.ServerCancelled); message="Parsing not finished"} , []
+    else
+      let proofs = Dm.DocumentManager.get_document_proofs st in
+      Ok Request.Client.DocumentProofsResult.{ proofs }, []
 
 let workspaceDidChangeConfiguration params = 
   let Lsp.Types.DidChangeConfigurationParams.{ settings } = params in

--- a/language-server/vscoqtop/lspManager.ml
+++ b/language-server/vscoqtop/lspManager.ml
@@ -546,6 +546,14 @@ let sendDocumentState id params =
   | Some { st } -> let document = Dm.DocumentManager.Internal.string_of_state st in
     Ok Request.Client.DocumentStateResult.{ document }, []
 
+let sendDocumentProofs id params = 
+  let Request.Client.DocumentProofsParams.{ textDocument } = params in
+  let uri = textDocument.uri in
+  match Hashtbl.find_opt states (DocumentUri.to_path uri) with
+  | None -> log @@ "[documentProofs] ignoring event on non existent document"; Error({message="Document does not exist"; code=None}), []
+  | Some { st } -> let proofs = Dm.DocumentManager.get_document_proofs st in
+    Ok Request.Client.DocumentProofsResult.{ proofs }, []
+
 let workspaceDidChangeConfiguration params = 
   let Lsp.Types.DidChangeConfigurationParams.{ settings } = params in
   let settings = Settings.t_of_yojson settings in
@@ -582,6 +590,7 @@ let dispatch_request : type a. Jsonrpc.Id.t -> a Request.Client.t -> (a,error) r
   | Print params -> coqtopPrint id params
   | Search params -> coqtopSearch id params
   | DocumentState params -> sendDocumentState id params
+  | DocumentProofs params -> sendDocumentProofs id params
 
 let dispatch_std_notification = 
   let open Lsp.Client_notification in function


### PR DESCRIPTION
This PR aims at exposing an API which will allow extensions to query the document and get proof blocks in a structured view. This can be useful for a number of users who which to build an extension to vscoq.

Down the line we also ended up fixing an outline bug, in which symbols were never removed but always added.