### PR TITLE
Fix incorrect reference to vscoq.trace.server

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ After installation and activation of the extension:
 #### Coq configuration
 * `"vscoq.path": ""` -- specify the path to `vscoqtop` (e.g. `path/to/vscoq/bin/vscoqtop`)
 * `"vscoq.args": []` -- an array of strings specifying additional command line arguments for `vscoqtop` (typically accepts the same flags as `coqtop`)
-* `"vscoq.trace.server": off | messages | verbose` -- Toggles the tracing of communications between the server and client
+* `"vscoq-language-server.trace.server": off | messages | verbose` -- Toggles the tracing of communications between the server and client
 
 #### Memory management (since >= 2.1.7)
 * `"vscoq.memory.limit: int` -- specifies the memory limit (in Gb) over which when a user closes a tab, the corresponding document state is discarded in the server to free up memory. Defaults to 4Gb.

--- a/client/package.json
+++ b/client/package.json
@@ -104,15 +104,16 @@
         "title": "Coq configuration",
         "type": "object",
         "properties": {
-          "vscoq.trace.server": {
+          "vscoq-language-server.trace.server": {
             "scope": "window",
             "type": "string",
             "enum": [
               "off",
               "messages",
+              "compact",
               "verbose"
             ],
-            "default": "messages",
+            "default": "off",
             "description": "Traces the communication between VS Code and the language server."
           },
           "vscoq.path": {


### PR DESCRIPTION
The README and the settings say to use `vscoq.trace.server`, but AFAICT this setting does nothing.  Looking at the code:

https://github.com/coq/vscoq/blob/26f3f1f70e329f72f1548f1a0ef929f20db36a4c/client/src/client.ts#L23-L28

… it appears that the right name is `vscoq-language-server`, not `vscoq`.  Indeed, with that setting set, I do get a trace (and I don't with the normal one).

An alternative fix would be to change the snippet above to have `vscoq` instead of `vscoq-language-server`.  Not sure what the consequences would be.