### PR TITLE
fix: ubuntu CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Use OCaml ${{ matrix.ocaml-compiler }}
-      uses: avsm/setup-ocaml@v2
+      uses: avsm/setup-ocaml@v3
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -144,7 +144,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Use OCaml ${{ matrix.ocaml-compiler }}
-      uses: avsm/setup-ocaml@v2
+      uses: avsm/setup-ocaml@v3
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 


### PR DESCRIPTION
Github is rolling out ubuntu 24.04 runners. This broke CI. Had to update setup-ocaml to v3.