### PR TITLE
Replaced custom searchForVscoqtopInPath code with which

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "compare-versions": "^6.0.0-rc.1",
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "^9.0.1",
+    "which": "^5.0.0"
   },
   "categories": [
     "Programming Languages"
@@ -967,6 +968,7 @@
     "@types/node": "16.x",
     "@types/tmp": "^0.2.3",
     "@types/vscode": "^1.74.0",
+    "@types/which": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "@vscode/test-electron": "^2.2.0",

--- a/client/src/utilities/toolchain.ts
+++ b/client/src/utilities/toolchain.ts
@@ -8,6 +8,7 @@ import { ServerOptions } from 'vscode-languageclient/node';
 import Client from '../client';
 import { version } from 'os';
 import { match } from 'assert';
+import * as which from 'which';
 
 export enum ToolChainErrorCode {
     notFound = 1, 
@@ -88,18 +89,6 @@ export default class VsCoqToolchainManager implements Disposable {
         return this._versionFullOutput;
     }
 
-    private getEnvPath() : string {
-        if(process.platform === 'win32') {
-            return process.env.Path ?? '';
-        } else {
-            return process.env.PATH ?? '';
-        }
-    }
-
-    private splitEnvPath(value: string) : string[] {
-        return value.split(path.delimiter);
-    }
-
     private async vscoqtopPath () : Promise<string> {
         const vscoqtopPath = workspace.getConfiguration('vscoq').get('path') as string;
         if(vscoqtopPath) {
@@ -110,15 +99,8 @@ export default class VsCoqToolchainManager implements Disposable {
         }
     }
 
-    private async searchForVscoqtopInPath () : Promise<string> {
-        const pathVars = this.splitEnvPath(this.getEnvPath());
-        for(let i in pathVars) {
-            Client.writeToVscoq2Channel("[Toolchain] " + pathVars[i]);
-            if(await isFileInFolder('vscoqtop', pathVars[i])) {
-                return pathVars[i] + '/vscoqtop';
-            }
-        }
-        return "";
+    private async searchForVscoqtopInPath () : Promise<string> {        
+        return await which("vscoqtop", { nothrow: true }) ?? "";
     }
 
     // Launch the vscoqtop -where command with the found exec and provided args

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -261,6 +261,11 @@
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.85.0.tgz#46beb07f0f626665b52d1e2294382b2bc63b602e"
   integrity sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==
 
+"@types/which@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-3.0.4.tgz#2c3a89be70c56a84a6957a7264639f39ae4340a1"
+  integrity sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -1640,6 +1645,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+isexe@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
+  integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
+
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
@@ -2854,6 +2864,13 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+which@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-5.0.0.tgz#d93f2d93f79834d4363c7d0c23e00d07c466c8d6"
+  integrity sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==
+  dependencies:
+    isexe "^3.1.1"
 
 wildcard@^2.0.0:
   version "2.0.1"

--- a/client/yarn.nix
+++ b/client/yarn.nix
@@ -322,6 +322,14 @@
       };
     }
     {
+      name = "_types_which___which_3.0.4.tgz";
+      path = fetchurl {
+        name = "_types_which___which_3.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/@types/which/-/which-3.0.4.tgz";
+        sha512 = "liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==";
+      };
+    }
+    {
       name = "_types_yargs_parser___yargs_parser_21.0.3.tgz";
       path = fetchurl {
         name = "_types_yargs_parser___yargs_parser_21.0.3.tgz";
@@ -1890,6 +1898,14 @@
       };
     }
     {
+      name = "isexe___isexe_3.1.1.tgz";
+      path = fetchurl {
+        name = "isexe___isexe_3.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz";
+        sha512 = "LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==";
+      };
+    }
+    {
       name = "isobject___isobject_3.0.1.tgz";
       path = fetchurl {
         name = "isobject___isobject_3.0.1.tgz";
@@ -3255,6 +3271,14 @@
         name = "which___which_2.0.2.tgz";
         url  = "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz";
         sha512 = "BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==";
+      };
+    }
+    {
+      name = "which___which_5.0.0.tgz";
+      path = fetchurl {
+        name = "which___which_5.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/which/-/which-5.0.0.tgz";
+        sha512 = "JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==";
       };
     }
     {


### PR DESCRIPTION
The client tests fail on my machine when running yarn test, but I tried installing a newly packaged .vsix and both my virtual windows and linux machines now find the correct path.

The error I am getting is:
DialogService: refused to show dialog in tests. Contents: Could not launch language server: ...
![image](https://github.com/user-attachments/assets/ad920c88-3e1d-42ee-bebe-401ac7955103)
