### PR TITLE
Block on parse error

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -50,12 +50,29 @@ type parsed_ast = {
   tokens: Tok.t list
 }
 
+type comment = {
+  start: int;
+  stop: int;
+  content: string;
+}
+
+type parsing_error = {
+  start: int;
+  stop: int;
+  msg: string Loc.located;
+  qf: Quickfix.t list option;
+}
+
+type sentence_state =
+  | Error of parsing_error
+  | Parsed of parsed_ast
+
 type pre_sentence = {
   parsing_start : int;
   start : int;
   stop : int;
   synterp_state : Vernacstate.Synterp.t; (* synterp state after this sentence's synterp phase *)
-  ast : parsed_ast;
+  ast : sentence_state;
 }
 
 (* Example:                        *)
@@ -70,21 +87,8 @@ type sentence = {
   synterp_state : Vernacstate.Synterp.t; (* synterp state after this sentence's synterp phase *)
   scheduler_state_before : Scheduler.state;
   scheduler_state_after : Scheduler.state;
-  ast : parsed_ast;
+  ast : sentence_state;
   id : sentence_id;
-}
-
-type comment = {
-  start: int;
-  stop: int;
-  content: string;
-}
-
-type parsing_error = {
-  start: int;
-  stop: int;
-  msg: string Loc.located;
-  qf: Quickfix.t list option;
 }
 
 type document = {
@@ -223,8 +227,13 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
     end
   | _ -> outline
 
+let record_outline document {id; ast} outline =
+  match ast with
+  | Error _ -> outline
+  | Parsed ast -> record_outline document id ast.ast ast.classification outline
+
 let compute_outline ({ sentences_by_end } as document) =
-    LM.fold (fun _ {id; ast} -> record_outline document id ast.ast ast.classification) sentences_by_end []
+    LM.fold (fun _ s -> record_outline document s) sentences_by_end []
 
 
 let schedule doc = doc.schedule
@@ -235,11 +244,14 @@ let outline doc = doc.outline
 let parse_errors parsed =
   List.map snd (LM.bindings parsed.parsing_errors_by_end)
 
-let add_sentence parsed parsing_start start stop (ast: parsed_ast) synterp_state scheduler_state_before =
+let add_sentence parsed parsing_start start stop (ast: sentence_state) synterp_state scheduler_state_before =
   let id = Stateid.fresh () in
-  let ast' = (ast.ast, ast.classification, synterp_state) in
-  let scheduler_state_after, schedule =
-    Scheduler.schedule_sentence (id, ast') scheduler_state_before parsed.schedule
+  let scheduler_state_after, schedule = 
+    match ast with
+    | Error _ -> scheduler_state_before, parsed.schedule (* If the sentence has a parsing error we do not schedule it *)
+    | Parsed ast ->
+      let ast' = (ast.ast, ast.classification, synterp_state) in
+      Scheduler.schedule_sentence (id, ast') scheduler_state_before parsed.schedule
   in
   (* FIXME may invalidate scheduler_state_XXX for following sentences -> propagate? *)
   let sentence = { parsing_start; start; stop; ast; id; synterp_state; scheduler_state_before; scheduler_state_after } in
@@ -337,9 +349,12 @@ let find_next_qed parsed loc =
   let exception Found of sentence in
   let f k sentence =
     if loc <= k then
-    match sentence.ast.classification with
-    | VtQed _ -> raise (Found sentence)
-    | _ -> () in
+    match sentence.ast with
+    | Error _ -> ()
+    | Parsed ast ->
+    match ast.classification with
+      | VtQed _ -> raise (Found sentence)
+      | _ -> () in
   (* We can't use find_first since f isn't monotone *)
   match LM.iter f parsed.sentences_by_end with
   | () -> None
@@ -373,12 +388,19 @@ let string_of_parsed_ast { tokens } =
   (* TODO implement printer for vernac_entry *)
   "[" ^ String.concat "--" (List.map (Tok.extract_string false) tokens) ^ "]"
 
+let string_of_parsed_ast = function
+| Error _ -> "errored sentence"
+| Parsed ast -> string_of_parsed_ast ast
+
 let patch_sentence parsed scheduler_state_before id ({ parsing_start; ast; start; stop; synterp_state } : pre_sentence) =
   let old_sentence = SM.find id parsed.sentences_by_id in
   log @@ Format.sprintf "Patching sentence %s , %s" (Stateid.to_string id) (string_of_parsed_ast old_sentence.ast);
   let scheduler_state_after, schedule =
-    let ast = (ast.ast, ast.classification, synterp_state) in
-    Scheduler.schedule_sentence (id,ast) scheduler_state_before parsed.schedule
+    match ast with
+    | Error _ -> scheduler_state_before, parsed.schedule
+    | Parsed ast ->
+      let ast = (ast.ast, ast.classification, synterp_state) in
+      Scheduler.schedule_sentence (id,ast) scheduler_state_before parsed.schedule
   in
   let new_sentence = { old_sentence with ast; parsing_start; start; stop; scheduler_state_before; scheduler_state_after } in
   let sentences_by_id = SM.add id new_sentence parsed.sentences_by_id in
@@ -398,7 +420,11 @@ type diff =
 
 
 let same_tokens (s1 : sentence) (s2 : pre_sentence) =
-    CList.equal Tok.equal s1.ast.tokens s2.ast.tokens
+  match s1.ast, s2.ast with
+  | Error _, Error _ -> false
+  | Parsed ast1, Parsed ast2 ->
+    CList.equal Tok.equal ast1.tokens ast2.tokens
+  | _, _ -> false
   
 (* TODO improve diff strategy (insertions,etc) *)
 let rec diff old_sentences new_sentences =
@@ -505,12 +531,15 @@ let get_entry ast =
 [%%endif]
 
 
-let handle_parse_error start msg qf ({stream; errors;} as parse_state) =
+let handle_parse_error start parsing_start msg qf ({stream; errors; parsed} as parse_state) =
   log @@ "handling parse error at " ^ string_of_int start;
   let stop = Stream.count stream in
   let parsing_error = { msg; start; stop; qf} in
+  let synterp_state = Vernacstate.Synterp.freeze () in
+  let sentence = { parsing_start; ast = Error parsing_error; start; stop; synterp_state } in
+  let parsed = sentence :: parsed in
   let errors = parsing_error :: errors in
-  let parse_state = {parse_state with errors} in
+  let parse_state = {parse_state with errors; parsed} in
   (* TODO: we could count the \n between start and stop and increase Loc.line_nb *)
   create_parsing_event (ParseEvent parse_state)
 
@@ -538,7 +567,8 @@ let handle_parse_more ({loc; synterp_state; stream; raw; parsed; parsed_comments
           let entry = get_entry ast in
           let classification = Vernac_classifier.classify_vernac ast in
           let synterp_state = Vernacstate.Synterp.freeze () in
-          let sentence = { parsing_start = start; ast = { ast = entry; classification; tokens }; start = begin_char; stop; synterp_state } in
+          let parsed_ast = Parsed { ast = entry; classification; tokens } in
+          let sentence = { parsing_start = start; ast = parsed_ast; start = begin_char; stop; synterp_state } in
           let parsed = sentence :: parsed in
           let comments = List.map (fun ((start, stop), content) -> {start; stop; content}) comments in
           let parsed_comments = List.append comments parsed_comments in
@@ -549,24 +579,24 @@ let handle_parse_more ({loc; synterp_state; stream; raw; parsed; parsed_comments
           let e, info = Exninfo.capture exn in
           let loc = get_loc_from_info_or_exn e info in
           let qf = Result.value ~default:[] @@ Quickfix.from_exception e in
-          handle_parse_error start (loc, Pp.string_of_ppcmds @@ CErrors.iprint_no_report (e,info)) (Some qf) parse_state
+          handle_parse_error start begin_char (loc, Pp.string_of_ppcmds @@ CErrors.iprint_no_report (e,info)) (Some qf) parse_state
         end
     | exception (E msg as exn) ->
       let loc = Loc.get_loc @@ Exninfo.info exn in
       let qf = Result.value ~default:[] @@ Quickfix.from_exception exn in
       junk_sentence_end stream;
-      handle_parse_error start (loc,msg) (Some qf) {parse_state with stream}
+      handle_parse_error start start (loc,msg) (Some qf) {parse_state with stream}
     | exception (CLexer.Error.E e as exn) -> (* May be more problematic to handle for the diff *)
       let loc = Loc.get_loc @@ Exninfo.info exn in
       let qf = Result.value ~default:[] @@ Quickfix.from_exception exn in
       junk_sentence_end stream;
-      handle_parse_error start (loc,CLexer.Error.to_string e) (Some qf) {parse_state with stream}
+      handle_parse_error start start (loc,CLexer.Error.to_string e) (Some qf) {parse_state with stream}
     | exception exn ->
       let e, info = Exninfo.capture exn in
       let loc = Loc.get_loc @@ info in
       let qf = Result.value ~default:[] @@ Quickfix.from_exception exn in
       junk_sentence_end stream;
-      handle_parse_error start (loc, "Unexpected parse error: " ^ Pp.string_of_ppcmds @@ CErrors.iprint_no_report (e,info)) (Some qf) {parse_state with stream}
+      handle_parse_error start start (loc, "Unexpected parse error: " ^ Pp.string_of_ppcmds @@ CErrors.iprint_no_report (e,info)) (Some qf) {parse_state with stream}
   end
 
 let rec unchanged_id id = function

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -84,7 +84,7 @@ type parsed_ast = {
 type parsing_error = {
   start: int; 
   stop: int; 
-  msg: string Loc.located;
+  msg: Pp.t Loc.located;
   qf: Quickfix.t list option;
 }
 

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -100,6 +100,10 @@ val apply_text_edits : document -> text_edit list -> document
 (** [apply_text_edits doc edits] updates the text of [doc] with [edits]. The new
     text is not parsed or executed. *)
 
+type sentence_state =
+  | Error of parsing_error
+  | Parsed of parsed_ast
+
 (* Example:                        *)
 (* "  Check 3. "                    *)
 (* ^  ^       ^---- end            *)
@@ -112,7 +116,7 @@ type sentence = {
   synterp_state : Vernacstate.Synterp.t; (* synterp state after this sentence's synterp phase *)
   scheduler_state_before : Scheduler.state;
   scheduler_state_after : Scheduler.state;
-  ast : parsed_ast;
+  ast : sentence_state;
   id : sentence_id;
 }
 

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -770,11 +770,14 @@ let hover st pos =
     match hover_of_sentence st loc pattern opt with
     | Some _ as x -> x
     | None -> 
-    match sentence.ast.classification with
+    match sentence.ast with
+    | Error _ -> None
+    | Parsed ast -> 
+      match ast.classification with
     (* next sentence in proof mode, hover at qed *)
-    | VtProofStep _ | VtStartProof _ -> 
+      | VtProofStep _ | VtStartProof _ -> 
         hover_of_sentence st loc pattern (Document.find_next_qed st.document loc)
-    | _ -> None
+      | _ -> None
 
 [%%if coq = "8.18" || coq = "8.19" || coq = "8.20"]
   let lconstr = Pcoq.Constr.lconstr

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -226,7 +226,7 @@ let mk_parsing_error_diag st Document.{ msg = (oloc,msg); start; stop; qf } =
         in
       Some code
   in
-  make_diagnostic st.document range oloc msg severity code
+  make_diagnostic st.document range oloc (Pp.string_of_ppcmds msg) severity code
 
 let all_diagnostics st =
   let parse_errors = Document.parse_errors st.document in

--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -587,7 +587,7 @@ let execute_task st (vs, events, interrupted) task =
       match task with
       | PBlock { id; error = err} ->
         let (loc, pp) = err in
-        let v = error None None pp vs in
+        let v = error loc None pp vs in
         let parse_error = Some (id, loc) in
         let st = update st id v in
         (st, vs, events, false, parse_error)

--- a/language-server/dm/scheduler.mli
+++ b/language-server/dm/scheduler.mli
@@ -37,6 +37,7 @@ type executable_sentence = {
 
 type task =
   | Skip of { id: sentence_id; error: Pp.t option }
+  | Block of { id: sentence_id; error: Pp.t Loc.located }
   | Exec of executable_sentence
   | OpaqueProof of { terminator: executable_sentence;
                      opener_id: sentence_id;
@@ -50,6 +51,8 @@ type schedule
     sentences *)
 
 val initial_schedule : schedule
+
+val schedule_errored_sentence : sentence_id -> Pp.t Loc.located -> schedule -> schedule
 
 val schedule_sentence : sentence_id * (Synterp.vernac_control_entry * Vernacextend.vernac_classification * Vernacstate.Synterp.t) -> state -> schedule -> state * schedule
 (** Identifies the structure of the document and dependencies between sentences

--- a/language-server/tests/common.ml
+++ b/language-server/tests/common.ml
@@ -74,9 +74,11 @@ let rec parse : type a. int -> int -> Document.sentence list -> Document.parsing
     | O, [], [] -> Ok ()
     | P spec, s :: l, errors ->
         parse (m+1) n l errors spec >>= (fun a -> Ok(ss_of_s s,a))
-    | E spec, sentences, error :: l ->
+    | E _, [], error :: _ ->
+        Error ("erroneous sentence not part of the document. Corresponding error is " ^ Pp.string_of_ppcmds @@ snd error.Document.msg)
+    | E spec, _ :: sentences, error :: l ->
         parse m (n+1) sentences l spec >>= (fun a -> Ok(error,a))
-    | O, (_ :: _ as l), _ -> Error ("more sentences than expected, extra " ^ Int.to_string (List.length l))
+    | O, (s :: _ as l), _ -> Error ("more sentences than expected, extra " ^ Int.to_string (List.length l) ^ ". Extra sentence is " ^ Document.Internal.string_of_sentence s)
     | O, _, (_ :: _ as l) -> Error ("more errors than expected, extra " ^ Int.to_string (List.length l))
     | P _, [], errors ->
       let errors = String.concat ~sep:"\n" @@ List.map ~f:(fun err -> Pp.string_of_ppcmds @@ snd err.Document.msg) errors in

--- a/language-server/tests/dm_tests.ml
+++ b/language-server/tests/dm_tests.ml
@@ -55,25 +55,31 @@ let%test_unit "parse.insert" =
   check_no_diag st
 
 let%test_unit "parse.squash" =
+                                              (*          1         2         3         4         5         6         7*)
+                                              (*01234567890123456789012345678901234567890123456789012345678901234567890*)
   let st, init_events = em_init_test_doc ~text:"Definition x := true. Definition y := false. Definition z := 0." in
   let st = edit_text st ~start:20 ~stop:21 ~text:"" in
   let doc = DocumentManager.Internal.document st in
   let sentences = Document.sentences doc in
   let start_positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.start) sentences in
   let stop_positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.stop) sentences in
-  [%test_eq: int list] start_positions [ 44 ];
-  [%test_eq: int list] stop_positions [ 62 ];
+  [%test_eq: int list] start_positions [ 0; 44 ];
+  [%test_eq: int list] stop_positions [ 43; 62 ];
   [%test_eq: int] (List.length (Document.parse_errors doc)) 1
 
 let%test_unit "parse.error_recovery" =
+                                              (*          1         2         3         4         5         6         7*)
+                                              (*01234567890123456789012345678901234567890123456789012345678901234567890*)
   let st, init_events = em_init_test_doc ~text:"## . Definition x := true. !! . Definition y := false." in
   let doc = DocumentManager.Internal.document st in
   let sentences = Document.sentences doc in
   let start_positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.start) sentences in
-  [%test_eq: int list] start_positions [ 5; 32 ];
+  [%test_eq: int list] start_positions [ 0; 5; 26; 32 ];
   [%test_eq: int] (List.length (Document.parse_errors doc)) 2
 
 let%test_unit "parse.extensions" =
+                                              (*          1         2         3         4         5         6         7*)
+                                              (*01234567890123456789012345678901234567890123456789012345678901234567890*)
   let st, init_events = em_init_test_doc ~text:"Notation \"## x\" := x (at level 0). Definition f (x : nat) := ##xx." in
   let sentences = Document.sentences @@ DocumentManager.Internal.document st in
   let start_positions = Stdlib.List.map (fun (s : Document.sentence) -> s.Document.start) sentences in


### PR DESCRIPTION
At the moment the mechanism for parse errors are different than exec errors.
This is a limitation as we cannot block on the first parse error.
We introduce a mechanism to record a sentence state allowing us to detect that a sentence has a parse error and prevent from executing it.
Closes #877 