### PR TITLE
Set light and contrast theme colors for warning messages to amber

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -861,8 +861,8 @@
         "description": "Color of warning messages.",
         "defaults": {
           "dark": "#ffff00",
-          "light": "#ffff00",
-          "highContrast": "#ffff00"
+          "light": "#ff6f00",
+          "highContrast": "#ff6f00"
         }
       },
       {


### PR DESCRIPTION
This should hopefully address #985 

How it appears for one of the default vscode light themes:
![image](https://github.com/user-attachments/assets/ae1629c2-405d-473f-8389-5a6ecfc54f5e)

How it appears for one of the default vscode dark themes:
![image](https://github.com/user-attachments/assets/05d273c7-286f-4a91-92b3-040d6efe4574)
