### PR TITLE
Change activation to only occur when Coq files are opened

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -29,10 +29,7 @@
   "readme": "https://github.com/coq-community/vscoq/blob/master/README.md",
   "bugs": "https://github.com/coq-community/vscoq/issues",
   "homepage": "https://github.com/coq-community/vscoq/blob/master/README.md",
-  "activationEvents": [
-    "workspaceContains:**/_CoqProject",
-    "workspaceContains:**/*.v"
-  ],
+  "activationEvents": [],
   "main": "./dist/extension.js",
   "contributes": {
     "languages": [

--- a/client/package.json
+++ b/client/package.json
@@ -93,7 +93,7 @@
           "type": "webview",
           "id": "vscoq.search",
           "name": "Query",
-          "when": "inCoqProject"
+          "when": "resourceLangId == coq || editorLangId == coq"
         }
       ]
     },

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -53,14 +53,6 @@ import { QUICKFIX_COMMAND, CoqWarningQuickFix } from './QuickFixProvider';
 let client: Client;
 
 export function activate(context: ExtensionContext) {
-    commands.executeCommand('setContext', 'inCoqProject', true);
-
-    function checkInCoqProject() {
-        workspace.findFiles('**/{*.v,_CoqProject}').then(files => {
-            commands.executeCommand('setContext', 'inCoqProject', files.length > 0);
-        });
-    }
-
     const getDocumentProofs = (uri: Uri) => {
         const textDocument = TextDocumentIdentifier.create(uri.toString());
         const params: DocumentProofsRequest = {textDocument};
@@ -69,10 +61,6 @@ export function activate(context: ExtensionContext) {
         return client.sendRequest(req, params);
     };
 
-    // Watch for files being added or removed
-    workspace.onDidCreateFiles(checkInCoqProject);
-    workspace.onDidDeleteFiles(checkInCoqProject);
-    
     const coqTM = new VsCoqToolchainManager();
     coqTM.intialize().then(
         () => {
@@ -391,5 +379,4 @@ Path: \`${coqTM.getVsCoqTopPath()}\`
 
 // This method is called when your extension is deactivated
 export function deactivate() {
-    commands.executeCommand('setContext', 'inCoqProject', undefined);
 }


### PR DESCRIPTION
Related to #1027.
In particular, you will not need the language server involved unless the extension is "activated", and **now** it should only activate if you have a focused `.v` or `_CoqProject` file.

How this should work (and in some ways a continuation of discussion in #897):
| Condition | Activate VsCoq |
| ----------- | ----------------------- |
| *.v file exists in the workspace | False |
| _CoqProject file exists in the workspace | False |
| *.v file is open | False |
| _CoqProject file is open | False |
| *.v file is focused | **True** | 
| _CoqProject file is focused | **True** |


It may also be worth addressing in this PR suggestions made by @RalfJung (in #897 discussion) about not displaying the sidebar unless you have a currently focused `.v` file. Upon testing, it appears that the sidebar search will not work if you don't have a currently focused `.v` file, so displaying it when it won't work would be at best confusing. 
If we choose to implement this, then additional commits will be needed for that functionality