### PR TITLE
EM: do not exec the same task twice

### DIFF
--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -374,7 +374,7 @@ let interpret_to st id check_mode =
     let pv_event = mk_proof_view_event id in
     st, [event] @ [pv_event]
   | Settings.Mode.Continuous ->
-    match ExecutionManager.is_executed st.execution_state id with
+    match ExecutionManager.is_locally_executed st.execution_state id with
     | true -> st, [mk_proof_view_event id]
     | false -> st, []
 
@@ -915,7 +915,7 @@ module Internal = struct
     let code_lines_by_id = Document.code_lines_sorted_by_loc st.document in
     let code_lines_by_end = Document.code_lines_by_end_sorted_by_loc st.document in
     let string_of_state id =
-      if ExecutionManager.is_executed st.execution_state id then "(executed)"
+      if ExecutionManager.is_locally_executed st.execution_state id then "(executed)"
       else if ExecutionManager.is_remotely_executed st.execution_state id then "(executed in worker)"
       else "(not executed)"
     in

--- a/language-server/dm/executionManager.mli
+++ b/language-server/dm/executionManager.mli
@@ -58,7 +58,11 @@ val reset_overview : state -> Document.document -> state
 val shift_overview : state -> before:RawDocument.t -> after:RawDocument.t -> start:int -> offset:int -> state
 val shift_diagnostics_locs : state -> start:int -> offset:int -> state
 val executed_ids : state -> sentence_id list
-val is_executed : state -> sentence_id -> bool
+
+(** we know if it worked and we have the state in this process *)
+val is_locally_executed : state -> sentence_id -> bool
+
+(** we know if it worked but we do not have the state in this process *)
 val is_remotely_executed : state -> sentence_id -> bool
 
 val get_context : state -> sentence_id -> (Evd.evar_map * Environ.env) option

--- a/language-server/tests/dm_tests.ml
+++ b/language-server/tests/dm_tests.ml
@@ -311,7 +311,7 @@ let%test_unit "edit.edit_non_root_observe_id_top" =
   let todo = Sel.Todo.(add init_events events) in
   let st = handle_dm_events todo st in
   let st = edit_text st ~start:0 ~stop:18 ~text:"Definition x := 3." in
-  [%test_eq: bool] (ExecutionManager.is_executed (DocumentManager.Internal.execution_state st) s2.id) false;
+  [%test_eq: bool] (ExecutionManager.is_locally_executed (DocumentManager.Internal.execution_state st) s2.id) false;
   [%test_eq: int option] (Option.map ~f:Stateid.to_int (DocumentManager.Internal.observe_id st)) None
 
 let%test_unit "edit.edit_non_root_observe_id" =
@@ -321,6 +321,6 @@ let%test_unit "edit.edit_non_root_observe_id" =
   let todo = Sel.Todo.(add init_events events) in
   let st = handle_dm_events todo st in
   let st = edit_text st ~start:19 ~stop:37 ~text:"Definition y := 4." in
-  [%test_eq: bool] (ExecutionManager.is_executed (DocumentManager.Internal.execution_state st) s3.id) false;
+  [%test_eq: bool] (ExecutionManager.is_locally_executed (DocumentManager.Internal.execution_state st) s3.id) false;
   [%test_eq: int option] (Option.map ~f:Stateid.to_int (DocumentManager.Internal.observe_id st))
     (Some (Stateid.to_int s1.id))


### PR DESCRIPTION
I guess this broke when we started flattening delegated task.
There are two options:
- we we flatten we filter upfront the tasks that are already done
- we make exec aware of the cache

I did the latter, since it is more "bullet proof", although the former is in more line with the code that already filters out done tasks when preparing them.