### PR TITLE
feat: adding sections and modules in outlines

### DIFF
--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -26,6 +26,9 @@ type proof_block_type =
   | TheoremKind of Decls.theorem_kind
   | DefinitionType of Decls.definition_object_kind
   | InductiveType of Vernacexpr.inductive_kind
+  | BeginSection
+  | BeginModule
+  | End
   | Other
 
 type proof_step = {
@@ -210,6 +213,11 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
     let vernac_gen_expr = ast.v.expr in
     let type_, statement = match vernac_gen_expr with
       | VernacSynterp (Synterp.EVernacExtend _) when names <> [] -> Some Other, "external"
+      | VernacSynterp (Synterp.EVernacBeginSection  _) -> log (fun () -> Format.sprintf "BEGIN SECTION %s" (string_of_id document id)); Some BeginSection, ""
+      | VernacSynterp (Synterp.EVernacDeclareModuleType  _) -> log (fun () -> Format.sprintf "BEGIN MODULE %s" (string_of_id document id)); Some BeginModule, ""
+      | VernacSynterp (Synterp.EVernacDefineModule  _) -> log (fun () -> Format.sprintf "BEGIN MODULE %s" (string_of_id document id)); Some BeginModule, ""
+      | VernacSynterp (Synterp.EVernacDeclareModule  _) -> log (fun () -> Format.sprintf "BEGIN MODULE %s" (string_of_id document id)); Some BeginModule, ""
+      | VernacSynterp (Synterp.EVernacEndSegment  _) -> log (fun () -> Format.sprintf "END SEGMENT"); Some End, ""
       | VernacSynterp _ -> None, ""
       | VernacSynPure pure -> 
         match pure with

--- a/language-server/dm/document.ml
+++ b/language-server/dm/document.ml
@@ -23,9 +23,9 @@ module LM = Map.Make (Int)
 module SM = Map.Make (Stateid)
 
 type proof_block_type =
-  | TheoremKind of Decls.theorem_kind
-  | DefinitionType of Decls.definition_object_kind
-  | InductiveType of Vernacexpr.inductive_kind
+  | TheoremKind
+  | DefinitionType
+  | InductiveType
   | BeginSection
   | BeginModule
   | End
@@ -191,10 +191,10 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
       | VernacSynterp _ -> None
       | VernacSynPure pure -> 
         match pure with
-        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind)
-        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def)
-        | Vernacexpr.VernacFixpoint (_, _) -> Some (DefinitionType Decls.Fixpoint)
-        | Vernacexpr.VernacCoFixpoint (_, _) -> Some (DefinitionType Decls.CoFixpoint)
+        | Vernacexpr.VernacStartTheoremProof _ -> Some TheoremKind
+        | Vernacexpr.VernacDefinition _ -> Some DefinitionType
+        | Vernacexpr.VernacFixpoint _ -> Some DefinitionType
+        | Vernacexpr.VernacCoFixpoint _ -> Some DefinitionType
         | _ -> None
     in
     let name = match names with
@@ -221,11 +221,11 @@ let record_outline document id (ast : Synterp.vernac_control_entry) classif (out
       | VernacSynterp _ -> None, ""
       | VernacSynPure pure -> 
         match pure with
-        | Vernacexpr.VernacStartTheoremProof (kind, _) -> Some (TheoremKind kind), string_of_id document id
-        | Vernacexpr.VernacDefinition ((_, def), _, _) -> Some (DefinitionType def), string_of_id document id
-        | Vernacexpr.VernacInductive (kind, _) -> Some (InductiveType kind), string_of_id document id
-        | Vernacexpr.VernacFixpoint (_, _) -> Some (DefinitionType Decls.Fixpoint), string_of_id document id
-        | Vernacexpr.VernacCoFixpoint (_, _) -> Some (DefinitionType Decls.CoFixpoint), string_of_id document id
+        | Vernacexpr.VernacStartTheoremProof _ -> Some TheoremKind, string_of_id document id
+        | Vernacexpr.VernacDefinition _ -> Some DefinitionType, string_of_id document id
+        | Vernacexpr.VernacInductive _ -> Some InductiveType, string_of_id document id
+        | Vernacexpr.VernacFixpoint _ -> Some DefinitionType, string_of_id document id
+        | Vernacexpr.VernacCoFixpoint _ -> Some DefinitionType, string_of_id document id
         | _ -> None, ""
     in
     let name = match names with

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -26,6 +26,9 @@ type proof_block_type =
   | TheoremKind of Decls.theorem_kind
   | DefinitionType of Decls.definition_object_kind
   | InductiveType of Vernacexpr.inductive_kind
+  | BeginSection
+  | BeginModule
+  | End
   | Other
 
 type proof_step = {

--- a/language-server/dm/document.mli
+++ b/language-server/dm/document.mli
@@ -23,9 +23,9 @@ open Lsp.Types
 type document
 
 type proof_block_type =
-  | TheoremKind of Decls.theorem_kind
-  | DefinitionType of Decls.definition_object_kind
-  | InductiveType of Vernacexpr.inductive_kind
+  | TheoremKind
+  | DefinitionType
+  | InductiveType
   | BeginSection
   | BeginModule
   | End

--- a/language-server/dm/documentManager.ml
+++ b/language-server/dm/documentManager.ml
@@ -351,6 +351,18 @@ let get_document_proofs st =
   let proofs, _  = List.partition is_theorem outline in
   List.map mk_proof_block proofs
 
+let to_document_symbol elem =
+  let Document.{name; statement; range; type_} = elem in
+  let kind = begin match type_ with
+  | TheoremKind -> SymbolKind.Function
+  | DefinitionType -> SymbolKind.Variable
+  | InductiveType -> SymbolKind.Struct
+  | Other -> SymbolKind.Null
+  | BeginSection | BeginModule -> SymbolKind.Class
+  | End -> SymbolKind.Null
+  end in
+  DocumentSymbol.{name; detail=(Some statement); kind; range; selectionRange=range; children=None; deprecated=None; tags=None;}
+
 let rec get_document_symbols outline (sec_or_m: DocumentSymbol.t list) symbols =
   let add_child (s_father: DocumentSymbol.t) s_child =
     let children = match s_father.children with
@@ -367,18 +379,6 @@ let rec get_document_symbols outline (sec_or_m: DocumentSymbol.t list) symbols =
     | s :: l ->
       let s = add_child s symbol in
       get_document_symbols outline (s::l) symbols
-  in
-  let to_document_symbol elem =
-    let Document.{name; statement; range; type_} = elem in
-    let kind = begin match type_ with
-    | TheoremKind -> SymbolKind.Function
-    | DefinitionType -> SymbolKind.Variable
-    | InductiveType -> SymbolKind.Struct
-    | Other -> SymbolKind.Null
-    | BeginSection | BeginModule -> SymbolKind.Class
-    | End -> SymbolKind.Null
-    end in
-    DocumentSymbol.{name; detail=(Some statement); kind; range; selectionRange=range; children=None; deprecated=None; tags=None;}
   in
   match outline with
   | [] -> symbols


### PR DESCRIPTION
We now support sections and modules which contain document symbols in the outline.
This is a preliminary step for #137 